### PR TITLE
Add next-seo integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "framer-motion": "^12.16.0",
         "next": "15.3.3",
+        "next-seo": "^6.8.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0"
@@ -4722,6 +4723,17 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-seo": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-6.8.0.tgz",
+      "integrity": "sha512-zcxaV67PFXCSf8e6SXxbxPaOTgc8St/esxfsYXfQXMM24UESUVSXFm7f2A9HMkAwa0Gqn4s64HxYZAGfdF4Vhg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "^8.1.1-canary.54 || >=9.0.0",
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,21 +9,22 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "framer-motion": "^12.16.0",
+    "next": "15.3.3",
+    "next-seo": "^6.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3",
-    "framer-motion": "^12.16.0",
     "react-icons": "^5.5.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import SEOProvider from "@/components/SEOProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <SEOProvider />
         {children}
       </body>
     </html>

--- a/src/components/SEOProvider.tsx
+++ b/src/components/SEOProvider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { DefaultSeo } from 'next-seo';
+import SEO from '@/seo.config';
+
+export default function SEOProvider() {
+  return <DefaultSeo {...SEO} />;
+}

--- a/src/seo.config.ts
+++ b/src/seo.config.ts
@@ -1,0 +1,22 @@
+import { DefaultSeoProps } from 'next-seo';
+
+const defaultSEOConfig: DefaultSeoProps = {
+  title: 'John Doe Portfolio',
+  description: 'Welcome to John Doe\'s personal website built with Next.js',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: 'https://example.com/',
+    siteName: 'John Doe Portfolio',
+    images: [
+      {
+        url: '/vercel.svg',
+        width: 1200,
+        height: 630,
+        alt: 'John Doe Portfolio',
+      },
+    ],
+  },
+};
+
+export default defaultSEOConfig;


### PR DESCRIPTION
## Summary
- install next-seo
- configure default SEO settings
- add `SEOProvider` component for injecting metadata
- use provider in root layout

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68413a95ac488320a726485ce180d29a