### PR TITLE
Fix tailwind config parsing issue

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,6 +1,5 @@
-import { type Config } from "tailwindcss";
-
-const config: Config = {
+/** @type {import('tailwindcss').Config} */
+const config = {
   content: ["./src/**/*.{ts,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- remove TypeScript-only syntax from `tailwind.config.mjs`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413f19744c8320a09c1a7848e84740